### PR TITLE
fix "permission denied"

### DIFF
--- a/docker.mk
+++ b/docker.mk
@@ -1,4 +1,4 @@
-USER := nobody
+USER := tirion
 HOME := /nonexistent
 ID := $(shell basename $(CURDIR))
 CONTAINER_ID := $(addsuffix _container, $(ID))


### PR DESCRIPTION

Как я выяснил, в контейнере директории с упражнением принадлежат пользователю `tirion`, а запуск тестов, согласно `docker.mk`, осуществляется от имени `nobody`.

Права:

```
bash-5.0$ whoami
nobody
bash-5.0$ ls -la
total 24
drwxrwxr-x 4 tirion tirion 4096 Aug 18 12:51 .
drwxr-xr-x 1 root   root   4096 Jul 30 08:57 ..
-rw-rw-r-- 1 tirion tirion  144 Aug 18 11:34 Makefile
drwxrwxr-x 3 tirion tirion 4096 Sep 18 08:09 out
-rw-rw-r-- 1 tirion tirion  711 Sep 18 19:17 sources.txt
drwxrwxr-x 3 tirion tirion 4096 Aug 18 11:34 src
```

Строки 1 и 17 в  `docker.mk` приводят к:

```
bash-5.0$ pwd
/usr/src/app
bash-5.0$ ls
Makefile  out  sources.txt  src
bash-5.0$ make
mkdir -p out
find . | grep java > sources.txt
/bin/sh: 1: cannot create sources.txt: Permission denied
make: *** [Makefile:3: test] Error 2
```

Не знаю кто виноват, `tirion` или `nobody`, но замена `nobody`на `tirion` помогла мне на локальном компьютере.